### PR TITLE
[US-368002] Add Ability to Provide Release ID instead of BSI Token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/PollingBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/PollingBuildStep.java
@@ -42,7 +42,8 @@ public class PollingBuildStep extends Recorder implements SimpleBuildStep {
     SharedPollingBuildStep sharedBuildStep;
 
     @DataBoundConstructor
-    public PollingBuildStep(String bsiToken,
+    public PollingBuildStep(String releaseId,
+                            String bsiToken,
                             boolean overrideGlobalConfig,
                             int pollingInterval,
                             int policyFailureBuildResultPreference,
@@ -52,7 +53,7 @@ public class PollingBuildStep extends Recorder implements SimpleBuildStep {
                             String personalAccessToken,
                             String tenantId) {
 
-        sharedBuildStep = new SharedPollingBuildStep(bsiToken,
+        sharedBuildStep = new SharedPollingBuildStep(releaseId, bsiToken,
                 overrideGlobalConfig, pollingInterval,
                 policyFailureBuildResultPreference, clientId, clientSecret,
                 username, personalAccessToken, tenantId);
@@ -71,6 +72,11 @@ public class PollingBuildStep extends Recorder implements SimpleBuildStep {
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
+    }
+
+    @SuppressWarnings("unused")
+    public String getReleaseId() {
+        return sharedBuildStep.getReleaseId();
     }
 
     @SuppressWarnings("unused")
@@ -134,12 +140,15 @@ public class PollingBuildStep extends Recorder implements SimpleBuildStep {
             return "Poll Fortify on Demand for Results";
         }
 
-        public FormValidation doCheckBsiToken(@QueryParameter String bsiToken) {
+        public FormValidation doCheckReleaseId(@QueryParameter String releaseId, @QueryParameter String bsiToken) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            return SharedPollingBuildStep.doCheckBsiToken(bsiToken);
-
+            return SharedPollingBuildStep.doCheckReleaseId(releaseId, bsiToken);
         }
 
+        public FormValidation doCheckBsiToken(@QueryParameter String bsiToken, @QueryParameter String releaseId) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return SharedPollingBuildStep.doCheckBsiToken(bsiToken, releaseId);
+        }
 
         public FormValidation doCheckPollingInterval(@QueryParameter String pollingInterval) {
             return SharedPollingBuildStep.doCheckPollingInterval(pollingInterval);

--- a/src/main/java/org/jenkinsci/plugins/fodupload/SharedPollingBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/SharedPollingBuildStep.java
@@ -36,6 +36,7 @@ public class SharedPollingBuildStep {
     public static final String PERSONAL_ACCESS_TOKEN = "personalAccessToken";
     public static final String TENANT_ID = "tenantId";
 
+    private String releaseId;
     private String bsiToken;
     private int pollingInterval;
 
@@ -43,7 +44,8 @@ public class SharedPollingBuildStep {
 
     private AuthenticationModel authModel;
 
-    public SharedPollingBuildStep(String bsiToken,
+    public SharedPollingBuildStep(String releaseId,
+                                  String bsiToken,
                                   boolean overrideGlobalConfig,
                                   int pollingInterval,
                                   int policyFailureBuildResultPreference,
@@ -53,6 +55,7 @@ public class SharedPollingBuildStep {
                                   String personalAccessToken,
                                   String tenantId) {
 
+        this.releaseId = releaseId;
         this.bsiToken = bsiToken;
         this.pollingInterval = pollingInterval;
         this.policyFailureBuildResultPreference = policyFailureBuildResultPreference;
@@ -62,7 +65,25 @@ public class SharedPollingBuildStep {
                 tenantId);
     }
 
-    public static FormValidation doCheckBsiToken(String bsiToken) {
+    public static FormValidation doCheckReleaseId(String releaseId, String bsiToken) {
+        if (releaseId != null && !releaseId.isEmpty()) {
+            try {
+                Integer testReleaseId = Integer.parseInt(releaseId);
+                return FormValidation.ok();
+            } catch (NumberFormatException ex) {
+                return FormValidation.error("Could not parse Release ID.");
+            }
+        }
+        else {
+            if (bsiToken != null && !bsiToken.isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            return FormValidation.error("Please specify Release ID or BSI Token.");
+        }
+    }
+
+    public static FormValidation doCheckBsiToken(String bsiToken, String releaseId) {
         if (bsiToken != null && !bsiToken.isEmpty()) {
             BsiTokenParser tokenParser = new BsiTokenParser();
             try {
@@ -73,9 +94,15 @@ public class SharedPollingBuildStep {
             } catch (Exception ex) {
                 return FormValidation.error("Could not parse BSI token.");
             }
-        } else
-            return FormValidation.error("Please specify BSI Token");
-        return FormValidation.error("Please specify BSI Token");
+        } else {
+            if (releaseId != null && !releaseId.isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            return FormValidation.error("Please specify Release ID or BSI Token.");
+        }
+
+        return FormValidation.error("Please specify Release ID or BSI Token.");
     }
 
     public static FormValidation doCheckPollingInterval(String pollingInterval) {
@@ -200,11 +227,19 @@ public class SharedPollingBuildStep {
 
         try {
 
-            BsiToken token = tokenParser.parse(this.getBsiToken());
+            Integer releaseIdNum = 0;
+            if (releaseId != null && !releaseId.isEmpty()) {
+                try {
+                    releaseIdNum = Integer.parseInt(releaseId);
+                } catch (NumberFormatException ex) {
+                }
+            }
+
+            BsiToken token = releaseIdNum == 0 ? tokenParser.parse(this.getBsiToken()) : null;
             if (apiConnection != null) {
                 apiConnection.authenticate();
                 ScanStatusPoller poller = new ScanStatusPoller(apiConnection, this.getPollingInterval(), logger);
-                PollReleaseStatusResult result = poller.pollReleaseStatus(token.getProjectVersionId());
+                PollReleaseStatusResult result = poller.pollReleaseStatus(releaseIdNum == 0 ? token.getProjectVersionId() : releaseIdNum);
 
                 // if the polling fails, crash the build
                 if (!result.isPollingSuccessful()) {
@@ -243,6 +278,10 @@ public class SharedPollingBuildStep {
                 apiConnection.retireToken();
             }
         }
+    }
+
+    public String getReleaseId() {
+        return releaseId;
     }
 
     public String getBsiToken() {

--- a/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.fodupload;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.text.Normalizer;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.fortify.fod.parser.BsiToken;
@@ -12,6 +13,7 @@ import org.jenkinsci.plugins.fodupload.controllers.StaticScanController;
 import org.jenkinsci.plugins.fodupload.models.AuthenticationModel;
 import org.jenkinsci.plugins.fodupload.models.FodEnums;
 import org.jenkinsci.plugins.fodupload.models.JobModel;
+import org.jenkinsci.plugins.fodupload.models.response.StaticScanSetupResponse;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -41,7 +43,8 @@ public class SharedUploadBuildStep {
     private JobModel model;
     private AuthenticationModel authModel;
 
-    public SharedUploadBuildStep(String bsiToken,
+    public SharedUploadBuildStep(String releaseId,
+                                 String bsiToken,
                                  boolean overrideGlobalConfig,
                                  String username,
                                  String personalAccessToken,
@@ -52,20 +55,39 @@ public class SharedUploadBuildStep {
                                  String remediationScanPreferenceType,
                                  String inProgressScanActionType) {
 
-        model = new JobModel(bsiToken,
+        model = new JobModel(releaseId,
+                bsiToken,
                 purchaseEntitlements,
                 entitlementPreference,
                 srcLocation,
                 remediationScanPreferenceType,
                 inProgressScanActionType);
-                
+
         authModel = new AuthenticationModel(overrideGlobalConfig,
                 username,
                 personalAccessToken,
                 tenantId);
     }
 
-    public static FormValidation doCheckBsiToken(String bsiToken) {
+    public static FormValidation doCheckReleaseId(String releaseId, String bsiToken) {
+        if (releaseId != null && !releaseId.isEmpty()) {
+            try {
+                Integer testReleaseId = Integer.parseInt(releaseId);
+                return FormValidation.ok();
+            } catch (NumberFormatException ex) {
+                return FormValidation.error("Could not parse Release ID.");
+            }
+        }
+        else {
+            if (bsiToken != null && !bsiToken.isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            return FormValidation.error("Please specify Release ID or BSI Token.");
+        }
+    }
+
+    public static FormValidation doCheckBsiToken(String bsiToken, String releaseId) {
         if (bsiToken != null && !bsiToken.isEmpty()) {
             BsiTokenParser tokenParser = new BsiTokenParser();
             try {
@@ -76,9 +98,15 @@ public class SharedUploadBuildStep {
             } catch (Exception ex) {
                 return FormValidation.error("Could not parse BSI token.");
             }
-        } else
-            return FormValidation.error("Please specify BSI Token");
-        return FormValidation.error("Please specify BSI Token");
+        } else {
+            if (releaseId != null && !releaseId.isEmpty()) {
+                return FormValidation.ok();
+            }
+
+            return FormValidation.error("Please specify Release ID or BSI Token.");
+        }
+
+        return FormValidation.error("Please specify Release ID or BSI Token.");
     }
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
@@ -155,8 +183,8 @@ public class SharedUploadBuildStep {
             return false;
         }
 
-        if (model.initializeBuildModel() == false) {
-            logger.println("Invalid BSI Token");
+        if ((model.getReleaseId() == null || model.getReleaseId().isEmpty()) && model.loadBsiToken() == false) {
+            logger.println("Invalid release ID or BSI Token");
             build.setResult(Result.FAILURE);
             return false;
         }
@@ -223,37 +251,57 @@ public class SharedUploadBuildStep {
 
             logger.println("Starting FoD Upload.");
 
-            if (model.getBsiToken() == null) { // Hack because pipeline step doesn't call prebuild
-                model.initializeBuildModel();
+            Integer releaseId = 0;
+            try {
+                releaseId = Integer.parseInt(model.getReleaseId());
             }
+            catch (NumberFormatException ex) {}
 
-            FilePath workspaceModified = new FilePath(workspace, model.getSrcLocation());
-            // zips the file in a temporary location
-            File payload = Utils.createZipFile(model.getBsiToken().getTechnologyStack(), workspaceModified, logger);
-            if (payload.length() == 0) {
-
-                boolean deleteSuccess = payload.delete();
-                if (!deleteSuccess) {
-                    logger.println("Unable to delete empty payload.");
-                }
-
-                logger.println("Source is empty for given Technology Stack and Language Level.");
-                build.setResult(Result.FAILURE);
-                return;
-            }
-
-            model.setPayload(payload);
+            String technologyStack = null;
+            StaticScanSetupResponse staticScanSetup = null;
 
             apiConnection = ApiConnectionFactory.createApiConnection(getAuthModel());
             if (apiConnection != null) {
                 apiConnection.authenticate();
 
                 StaticScanController staticScanController = new StaticScanController(apiConnection, logger);
+
+                if (releaseId == 0) {
+                    model.loadBsiToken();
+                    technologyStack = model.getBsiToken().getTechnologyStack();
+                } else {
+                    staticScanSetup = staticScanController.getStaticScanSettings(releaseId);
+                    if (staticScanSetup == null) {
+                        logger.println("No scan settings defined for release " + releaseId.toString());
+                        build.setResult(Result.FAILURE);
+                        return;
+                    }
+
+                    technologyStack = staticScanSetup.getTechnologyStack();
+                }
+
+                FilePath workspaceModified = new FilePath(workspace, model.getSrcLocation());
+                // zips the file in a temporary location
+                File payload = Utils.createZipFile(technologyStack, workspaceModified, logger);
+                if (payload.length() == 0) {
+
+                    boolean deleteSuccess = payload.delete();
+                    if (!deleteSuccess) {
+                        logger.println("Unable to delete empty payload.");
+                    }
+
+                    logger.println("Source is empty for given Technology Stack and Language Level.");
+                    build.setResult(Result.FAILURE);
+                    return;
+                }
+
+                model.setPayload(payload);
+
                 String notes = String.format("[%d] %s - Assessment submitted from Jenkins FoD Plugin",
                         build.getNumber(),
                         build.getDisplayName());
 
-                boolean success = staticScanController.startStaticScan(model, notes);
+                boolean success = staticScanController.startStaticScan(releaseId, staticScanSetup, model, notes);
                 boolean deleted = payload.delete();
 
                 if (success && deleted) {
@@ -291,6 +339,8 @@ public class SharedUploadBuildStep {
        
         return displayModel;
     }
+
+    public JobModel setModel(JobModel newModel) { return model = newModel; }
     
     public AuthenticationModel setAuthModel(AuthenticationModel newAuthModel) {
         return authModel = newAuthModel;

--- a/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
@@ -9,6 +9,7 @@ import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.security.Permission;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
@@ -42,7 +43,8 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
     // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
     // Entry point when building
     @DataBoundConstructor
-    public StaticAssessmentBuildStep(String bsiToken,
+    public StaticAssessmentBuildStep(String releaseId,
+                                     String bsiToken,
                                      boolean overrideGlobalConfig,
                                      String username,
                                      String personalAccessToken,
@@ -53,7 +55,8 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
                                      String remediationScanPreferenceType,
                                      String inProgressScanActionType) {
 
-        sharedBuildStep = new SharedUploadBuildStep(bsiToken,
+        sharedBuildStep = new SharedUploadBuildStep(releaseId,
+                bsiToken,
                 overrideGlobalConfig,
                 username,
                 personalAccessToken,
@@ -92,6 +95,11 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
+    }
+
+    @SuppressWarnings("unused")
+    public String getReleaseId() {
+        return sharedBuildStep.getModel().getReleaseId();
     }
 
     // NOTE: The following Getters are used to return saved values in the config.jelly. Intellij
@@ -166,9 +174,14 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
             return true;
         }
 
-        public FormValidation doCheckBsiToken(@QueryParameter String bsiToken) {
+        public FormValidation doCheckReleaseId(@QueryParameter String releaseId, @QueryParameter String bsiToken) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            return SharedUploadBuildStep.doCheckBsiToken(bsiToken);
+            return SharedUploadBuildStep.doCheckReleaseId(releaseId, bsiToken);
+        }
+
+        public FormValidation doCheckBsiToken(@QueryParameter String bsiToken, @QueryParameter String releaseId) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return SharedUploadBuildStep.doCheckBsiToken(bsiToken, releaseId);
         }
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
@@ -29,7 +29,7 @@ public class JobModel {
 
     /**
      * Build model used to pass values around
-     * @param releaseId                     Releaes ID
+     * @param releaseId                     Release ID
      * @param bsiToken                      BSI Token
      * @param purchaseEntitlements          purchaseEntitlements
      * @param entitlementPreference         entitlementPreference

--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/response/StaticScanSetupResponse.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/response/StaticScanSetupResponse.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.fodupload.models.response;
+
+public class StaticScanSetupResponse {
+    private int assessmentTypeId;
+    private int entitlementId;
+    private int entitlementFrequencyTypeId;
+    private int releaseId;
+    private String technologyStack;
+    private int technologyStackId;
+    private int languageLevelId;
+    private String languageLevel;
+    private boolean performOpenSourceAnalysis;
+    private int auditPreferenceTypeId;
+    private boolean includeThirdPartyLibraries;
+    private boolean useSourceControl;
+    private String bsiToken;
+
+    public int getAssessmentTypeId() {
+        return assessmentTypeId;
+    }
+
+    public int getEntitlementId() {
+        return entitlementId;
+    }
+
+    public int getEntitlementFrequencyTypeId() {
+        return entitlementFrequencyTypeId;
+    }
+
+    public int getReleaseId() {
+        return releaseId;
+    }
+
+    public int getTechnologyStackId() {
+        return technologyStackId;
+    }
+
+    public int getLanguageLevelId() {
+        return languageLevelId;
+    }
+
+    public boolean isPerformOpenSourceAnalysis() {
+        return performOpenSourceAnalysis;
+    }
+
+    public int getAuditPreferenceTypeId() {
+        return auditPreferenceTypeId;
+    }
+
+    public boolean isIncludeThirdPartyLibraries() {
+        return includeThirdPartyLibraries;
+    }
+
+    public boolean isUseSourceControl() {
+        return useSourceControl;
+    }
+
+    public String getBsiToken() {
+        return bsiToken;
+    }
+
+    public String getTechnologyStack() {
+        return technologyStack;
+    }
+
+    public String getLanguageLevel() {
+        return languageLevel;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults.java
@@ -32,6 +32,7 @@ import org.kohsuke.stapler.verb.POST;
 @SuppressFBWarnings("unused")
 public class FortifyPollResults extends FortifyStep {
 
+    private String releaseId;
     private String bsiToken;
     private int pollingInterval;
 
@@ -46,11 +47,14 @@ public class FortifyPollResults extends FortifyStep {
     private SharedPollingBuildStep commonBuildStep;
 
     @DataBoundConstructor
-    public FortifyPollResults(String bsiToken, int pollingInterval) {
+    public FortifyPollResults(String releaseId, String bsiToken, int pollingInterval) {
         super();
+        this.releaseId = releaseId != null ? releaseId.trim() : "";
         this.bsiToken = bsiToken != null ? bsiToken.trim() : "";
         this.pollingInterval = pollingInterval;
     }
+
+    public String getReleaseId() { return this.releaseId; }
 
     public String getBsiToken() {
         return this.bsiToken;
@@ -128,7 +132,8 @@ public class FortifyPollResults extends FortifyStep {
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
         PrintStream log = listener.getLogger();
         log.println("Fortify on Demand Poll Results PreBuild Running...");
-        commonBuildStep = new SharedPollingBuildStep(bsiToken,
+        commonBuildStep = new SharedPollingBuildStep(releaseId,
+                bsiToken,
                 overrideGlobalConfig,
                 pollingInterval,
                 policyFailureBuildResultPreference,
@@ -151,7 +156,8 @@ public class FortifyPollResults extends FortifyStep {
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
         PrintStream log = listener.getLogger();
         log.println("Fortify on Demand Poll Results Running...");
-        commonBuildStep = new SharedPollingBuildStep(bsiToken,
+        commonBuildStep = new SharedPollingBuildStep(releaseId,
+                bsiToken,
                 overrideGlobalConfig,
                 pollingInterval,
                 policyFailureBuildResultPreference,

--- a/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
@@ -34,6 +34,7 @@ public class FortifyStaticAssessment extends FortifyStep {
 
     private static final ThreadLocal<TaskListener> taskListener = new ThreadLocal<>();
 
+    private String releaseId;
     private String bsiToken;
 
     private boolean overrideGlobalConfig;
@@ -49,14 +50,17 @@ public class FortifyStaticAssessment extends FortifyStep {
     private SharedUploadBuildStep commonBuildStep;
 
     @DataBoundConstructor
-    public FortifyStaticAssessment(String bsiToken) {
+    public FortifyStaticAssessment(String releaseId, String bsiToken) {
         super();
+        this.releaseId = releaseId != null ? releaseId.trim() : "";
         this.bsiToken = bsiToken != null ? bsiToken.trim() : "";
     }
 
     public String getBsiToken() {
         return bsiToken;
     }
+
+    public String getReleaseId() { return releaseId; }
 
     public boolean getOverrideGlobalConfig() {
         return overrideGlobalConfig;
@@ -144,7 +148,8 @@ public class FortifyStaticAssessment extends FortifyStep {
     public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
         PrintStream log = listener.getLogger();
         log.println("Fortify on Demand Upload PreBuild Running...");
-        commonBuildStep = new SharedUploadBuildStep(bsiToken,
+        commonBuildStep = new SharedUploadBuildStep(releaseId,
+                bsiToken,
                 overrideGlobalConfig,
                 username,
                 personalAccessToken,
@@ -168,7 +173,8 @@ public class FortifyStaticAssessment extends FortifyStep {
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) {
         PrintStream log = listener.getLogger();
         log.println("Fortify on Demand Upload Running...");
-        commonBuildStep = new SharedUploadBuildStep(bsiToken,
+        commonBuildStep = new SharedUploadBuildStep(releaseId,
+                bsiToken,
                 overrideGlobalConfig,
                 username,
                 personalAccessToken,

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/PollingBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/PollingBuildStep/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
+        <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
+        <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
+        <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment/config.jelly
@@ -1,5 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Release ID" field="releaseId" help="/plugin/fortify-on-demand-uploader/help-releaseId.html">
+        <f:textbox />
+    </f:entry>
     <f:entry title="BSI Token" field="bsiToken">
         <f:textbox />
     </f:entry>

--- a/src/main/webapp/help-releaseId.html
+++ b/src/main/webapp/help-releaseId.html
@@ -1,0 +1,3 @@
+<div>
+    The release ID provides a CI token that never changes. The release ID is HIGHLY recommended for CI usage as the BSI token is being sunset in 2020
+</div>


### PR DESCRIPTION
https://almoctane-ams.saas.microfocus.com/ui/entity-navigation?p=112082/7001&entityType=work_item&id=368002

## Changes
1. The user can provide an integer `Release ID` instead of `BSI Token`.
2. In case both fields are present, release id will be favored.

![image](https://user-images.githubusercontent.com/59571582/79014799-a3d1a800-7b39-11ea-8c7c-e1c912f5f80f.png)