### PR TITLE
[D-428009] fix re-authentication and send correlation id

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/FodApiConnection.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/FodApiConnection.java
@@ -173,5 +173,11 @@ public class FodApiConnection {
     public OkHttpClient getClient() {
         return client;
     }
+
+    public Request reauthenticateRequest(Request request) {
+        return request.newBuilder()
+                .header("Authorization", "Bearer " + getToken())
+                .build();
+    }
 }
 

--- a/src/main/java/org/jenkinsci/plugins/fodupload/PollingBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/PollingBuildStep.java
@@ -73,6 +73,7 @@ public class PollingBuildStep extends Recorder implements SimpleBuildStep {
         // If the CrossBuildAction fails to save during the upload step, the polling fails semi-gracefully.
         if(run.getAction(CrossBuildAction.class) != null && run.getAction(CrossBuildAction.class).allowPolling()) {
             sharedBuildStep.setUploadScanId(run.getAction(CrossBuildAction.class).currentScanId());
+            sharedBuildStep.setCorrelationId(run.getAction(CrossBuildAction.class).currentCorrelationId());
             sharedBuildStep.perform(run, filePath, launcher, taskListener);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/SharedPollingBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/SharedPollingBuildStep.java
@@ -44,6 +44,7 @@ public class SharedPollingBuildStep {
     private String bsiToken;
     private int pollingInterval;
     private int scanId;
+    private String correlationId;
 
     private int policyFailureBuildResultPreference;
 
@@ -65,6 +66,7 @@ public class SharedPollingBuildStep {
         this.pollingInterval = pollingInterval;
         this.policyFailureBuildResultPreference = policyFailureBuildResultPreference;
         this.scanId = -1;
+        this.correlationId = "";
         authModel = new AuthenticationModel(overrideGlobalConfig,
                 username,
                 personalAccessToken,
@@ -265,7 +267,7 @@ public class SharedPollingBuildStep {
             if (apiConnection != null) {
                 apiConnection.authenticate();
                 ScanStatusPoller poller = new ScanStatusPoller(apiConnection, this.getPollingInterval(), logger);
-                PollReleaseStatusResult result = poller.pollReleaseStatus(releaseIdNum == 0 ? token.getProjectVersionId() : releaseIdNum, scanId);
+                PollReleaseStatusResult result = poller.pollReleaseStatus(releaseIdNum == 0 ? token.getProjectVersionId() : releaseIdNum, scanId, correlationId);
 
                 // if the polling fails, crash the build
                 if (!result.isPollingSuccessful()) {
@@ -333,6 +335,10 @@ public class SharedPollingBuildStep {
 
     public void setUploadScanId(int uploadScanId) {
         this.scanId = uploadScanId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
     }
 
     public AuthenticationModel getAuthModel() {

--- a/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/SharedUploadBuildStep.java
@@ -219,7 +219,7 @@ public class SharedUploadBuildStep {
 
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public void perform(Run<?, ?> build, FilePath workspace,
-                        Launcher launcher, TaskListener listener) {
+                        Launcher launcher, TaskListener listener, String correlationId) {
 
         final PrintStream logger = listener.getLogger();
         FodApiConnection apiConnection = null;
@@ -271,6 +271,7 @@ public class SharedUploadBuildStep {
             }
 
             logger.println("Starting FoD Upload.");
+            logger.println("Correlation Id = " + correlationId);
 
             Integer releaseId = 0;
             try {
@@ -296,7 +297,7 @@ public class SharedUploadBuildStep {
             if (apiConnection != null) {
                 apiConnection.authenticate();
 
-                StaticScanController staticScanController = new StaticScanController(apiConnection, logger);
+                StaticScanController staticScanController = new StaticScanController(apiConnection, logger, correlationId);
 
                 if (releaseId == 0) {
                     model.loadBsiToken();

--- a/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/StaticAssessmentBuildStep.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.util.UUID;
 
 import jenkins.model.Jenkins;
 
@@ -92,12 +93,16 @@ public class StaticAssessmentBuildStep extends Recorder implements SimpleBuildSt
                             PrintStream log = listener.getLogger();
         build.addAction(new CrossBuildAction());
         try{build.save();} catch(IOException ex){log.println("Error saving settings. Error message: " + ex.toString());}
-        sharedBuildStep.perform(build, workspace, launcher, listener);
+
+        String correlationId = UUID.randomUUID().toString();
+
+        sharedBuildStep.perform(build, workspace, launcher, listener, correlationId);
 
         CrossBuildAction crossBuildAction = build.getAction(CrossBuildAction.class);
         crossBuildAction.setPreviousStepBuildResult(build.getResult());
         if(Result.SUCCESS.equals(crossBuildAction.getPreviousStepBuildResult())) {
             crossBuildAction.setScanId(sharedBuildStep.getScanId());
+            crossBuildAction.setCorrelationId(correlationId);
         }
         try{build.save();} catch(IOException ex){log.println("Error saving settings. Error message: " + ex.toString());}
     }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/Utils.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/Utils.java
@@ -15,6 +15,8 @@ import java.util.regex.Pattern;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 
+import okhttp3.Response;
+import org.apache.http.HttpStatus;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public class Utils {
@@ -175,5 +177,9 @@ public class Utils {
                 )
         );
         return s != null ? decrypt(s.getSecret()) : id;
+    }
+
+    public static Boolean isUnauthorizedResponse(Response response) {
+        return response.code() == HttpStatus.SC_FORBIDDEN || response.code() == HttpStatus.SC_UNAUTHORIZED;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/actions/CrossBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/actions/CrossBuildAction.java
@@ -8,6 +8,7 @@ public class CrossBuildAction implements Action {
     private Result previousStepBuildResult;
     private boolean allowPolling;
     private int scanId;
+    private String correlationId;
 
     public Result getPreviousStepBuildResult() {
         return previousStepBuildResult;
@@ -26,12 +27,18 @@ public class CrossBuildAction implements Action {
         this.scanId = uploadScanId;
     }
 
+    public void setCorrelationId(String correlationId) { this.correlationId = correlationId; }
+
     public boolean allowPolling() {
         return allowPolling;
     }
 
     public int currentScanId() {
         return scanId;
+    }
+
+    public String currentCorrelationId() {
+        return correlationId;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/ControllerBase.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/ControllerBase.java
@@ -2,16 +2,32 @@ package org.jenkinsci.plugins.fodupload.controllers;
 
 import org.jenkinsci.plugins.fodupload.FodApiConnection;
 
+import java.io.PrintStream;
+
 abstract class ControllerBase {
 
     protected FodApiConnection apiConnection;
+    protected PrintStream logger;
+    protected String correlationId;
 
     /**
      * Base constructor for all apiConnection controllers
      *
      * @param apiConnection apiConnection object (containing client etc.) of controller
+     * @param logger logger object
+     * @param correlationId correlation id
      */
-    ControllerBase(FodApiConnection apiConnection) {
+    ControllerBase(final FodApiConnection apiConnection, final PrintStream logger, final String correlationId) {
         this.apiConnection = apiConnection;
+        this.logger = logger;
+        this.correlationId = correlationId;
+    }
+
+    protected String getCorrelationId() {
+        if (this.correlationId == null) {
+            return "";
+        }
+
+        return this.correlationId;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/controllers/LookupItemsController.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/controllers/LookupItemsController.java
@@ -12,6 +12,7 @@ import org.jenkinsci.plugins.fodupload.models.response.LookupItemsModel;
 import org.jenkinsci.plugins.fodupload.models.response.GenericListResponse;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.lang.reflect.Type;
 import java.util.List;
 
@@ -20,9 +21,11 @@ public class LookupItemsController extends ControllerBase {
      * Constructor
      *
      * @param apiConnection apiConnection connection object with client info
+     * @param logger logger object
+     * @param correlationId correlation id
      */
-    public LookupItemsController(FodApiConnection apiConnection) {
-        super(apiConnection);
+    public LookupItemsController(final FodApiConnection apiConnection, final PrintStream logger, final String correlationId) {
+        super(apiConnection, logger, correlationId);
     }
 
     /**
@@ -46,6 +49,7 @@ public class LookupItemsController extends ControllerBase {
                 .url(url)
                 .addHeader("Authorization", "Bearer " + apiConnection.getToken())
                 .addHeader("Accept", "application/json")
+                .addHeader("CorrelationId", getCorrelationId())
                 .get()
                 .build();
         Response response = apiConnection.getClient().newCall(request).execute();

--- a/src/main/java/org/jenkinsci/plugins/fodupload/polling/ScanStatusPoller.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/polling/ScanStatusPoller.java
@@ -46,14 +46,14 @@ public class ScanStatusPoller {
      * @throws java.io.IOException  in certain cases
      * @throws InterruptedException in certain cases
      */
-    public PollReleaseStatusResult pollReleaseStatus(final int releaseId, final int scanId) throws IOException, InterruptedException {
+    public PollReleaseStatusResult pollReleaseStatus(final int releaseId, final int scanId, final String correlationId) throws IOException, InterruptedException {
 
 
         logger.println("Begin polling Fortify on Demand for results.");
 
         boolean finished = false;
         int counter = 1;
-        LookupItemsController lookupItemsController = new LookupItemsController(this.apiConnection);
+        LookupItemsController lookupItemsController = new LookupItemsController(this.apiConnection, logger, correlationId);
         List<LookupItemsModel> analysisStatusTypes =  lookupItemsController.getLookupItems(APILookupItemTypes.AnalysisStatusTypes);
         StatusPollerThread pollerThread = null;
 
@@ -80,9 +80,9 @@ public class ScanStatusPoller {
                 }
                 if (counter == 1) {
                     //No Thread.sleep() on first round
-                    pollerThread = new StatusPollerThread(String.valueOf(counter), releaseId, analysisStatusTypes, apiConnection, complete, logger, 0, scanId);
+                    pollerThread = new StatusPollerThread(String.valueOf(counter), releaseId, analysisStatusTypes, apiConnection, complete, logger, 0, scanId, correlationId);
                 } else {
-                    pollerThread = new StatusPollerThread(String.valueOf(counter), releaseId, analysisStatusTypes, apiConnection, complete, logger, pollingInterval, scanId);
+                    pollerThread = new StatusPollerThread(String.valueOf(counter), releaseId, analysisStatusTypes, apiConnection, complete, logger, pollingInterval, scanId, correlationId);
                 }
 
                 pollerThread.start();

--- a/src/main/java/org/jenkinsci/plugins/fodupload/polling/StatusPollerThread.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/polling/StatusPollerThread.java
@@ -28,12 +28,12 @@ class StatusPollerThread extends Thread {
 
 
     StatusPollerThread(String name, final int releaseId, List<LookupItemsModel> analysisStatusTypes,
-                       FodApiConnection apiConnection, List<String> completeStatusList, PrintStream logger, int pollingInterval, final int scanId) {
+                       FodApiConnection apiConnection, List<String> completeStatusList, PrintStream logger, int pollingInterval, final int scanId, final String correlationId) {
         super(name);
         this.releaseId = releaseId;
         this.analysisStatusTypes = analysisStatusTypes;
         this.logger = logger;
-        this.releaseController = new ReleaseController(apiConnection);
+        this.releaseController = new ReleaseController(apiConnection, logger, correlationId);
         this.completeStatusList = completeStatusList;
         this.pollingInterval = pollingInterval;
         this.scanId = scanId;

--- a/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyPollResults.java
@@ -172,6 +172,7 @@ public class FortifyPollResults extends FortifyStep {
 // If the CrossBuildAction fails to save during the upload step, the polling fails semi-gracefully.
         if(build.getAction(CrossBuildAction.class) != null && build.getAction(CrossBuildAction.class).allowPolling()) {
             commonBuildStep.setUploadScanId(build.getAction(CrossBuildAction.class).currentScanId());
+            commonBuildStep.setCorrelationId(build.getAction(CrossBuildAction.class).currentCorrelationId());
             commonBuildStep.perform(build, workspace, launcher, listener);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/steps/FortifyStaticAssessment.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.fodupload.steps;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -199,6 +200,8 @@ public class FortifyStaticAssessment extends FortifyStep {
         inProgressScanActionType = inProgressScanActionType != null ? inProgressScanActionType : FodEnums.InProgressScanActionType.DoNotStartScan.getValue();
         inProgressBuildResultType = inProgressBuildResultType != null ? inProgressBuildResultType : FodEnums.InProgressBuildResultType.FailBuild.getValue();
 
+        String correlationId = UUID.randomUUID().toString();
+
         commonBuildStep = new SharedUploadBuildStep(releaseId,
                 bsiToken,
                 overrideGlobalConfig,
@@ -212,11 +215,12 @@ public class FortifyStaticAssessment extends FortifyStep {
                 inProgressScanActionType,
                 inProgressBuildResultType);
 
-        commonBuildStep.perform(build, workspace, launcher, listener);
+        commonBuildStep.perform(build, workspace, launcher, listener, correlationId);
         CrossBuildAction crossBuildAction = build.getAction(CrossBuildAction.class);
         crossBuildAction.setPreviousStepBuildResult(build.getResult());
         if(Result.SUCCESS.equals(crossBuildAction.getPreviousStepBuildResult())) {
             crossBuildAction.setScanId(commonBuildStep.getScanId());
+            crossBuildAction.setCorrelationId(correlationId);
         }
         try{build.save();} catch(IOException ex){log.println("Error saving settings. Error message: " + ex.toString());}
     }


### PR DESCRIPTION
https://almoctane-ams.saas.microfocus.com/ui/entity-navigation?p=112082/7001&entityType=work_item&id=428009

There was this problem, that after 4 hours, polling would stop (see details in ticket)

Turns out, we didn't detect expired token properly and didn't authenticate properly.

This PR:

1. Fixed re-authentication
2. Generates correlation id to improve diagnostic of future problems