### PR TITLE
[D-429008] fix step persistence 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
+++ b/src/main/java/org/jenkinsci/plugins/fodupload/models/JobModel.java
@@ -100,11 +100,6 @@ public class JobModel {
         return inProgressBuildResultType;
     }
 
-    private Object readResolve() throws URISyntaxException, UnsupportedEncodingException {
-        bsiTokenCache = tokenParser.parse(bsiTokenOriginal);
-        return this;
-    }
-
     @Override
     public String toString() {
         if (bsiTokenCache != null) {


### PR DESCRIPTION
https://almoctane-ams.saas.microfocus.com/ui/entity-navigation?p=112082/7001&entityType=work_item&id=429008

It looks like the Jenkins plugin deserialization mechanism would automatically invoke methods that start with `read`, and would fail the entire deserialization process if an exception was thrown. (which would happen if the user saves the job with an empty BSI token).

I removed the method that causes the exceptions. It looks like that method was never used and everything works fine without it.